### PR TITLE
fix: Update asset upload step in GitHub Actions to use .tgz files

### DIFF
--- a/.github/workflows/qb-build-kafka.yml
+++ b/.github/workflows/qb-build-kafka.yml
@@ -88,7 +88,7 @@ jobs:
         uses: netcracker/qubership-workflow-hub/actions/assets-action@main
         with:
           tag: ${{ inputs.tag }}
-          item-path: core/build/apache-cassandra-*.tar.gz, NEWS.txt, NOTICE.txt, ci
+          item-path: core/build/distributions/*.tgz
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
fix:  Change the asset upload step to utilize .tgz files instead of
.tar.gz files for improved compatibility.
