### PR TITLE
Fix GitHub Actions tag action reference

### DIFF
--- a/.github/workflows/qb-build-kafka.yml
+++ b/.github/workflows/qb-build-kafka.yml
@@ -33,13 +33,14 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Create a New Tag
-        uses: nookyo/qubership-workflow-hub/actions/tag-action@main
+        uses: netcracker/qubership-workflow-hub/actions/tag-action@main
         with:
           ref: ${{ github.ref_name }}
           tag-name: ${{ inputs.tag }}
           force-create: ${{ inputs.forceCreate }}
           switch-to-tag: true
           create-release: true
+          skip-checkout: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Update the tag action step in the GitHub Actions workflow to use the
correct action reference and add a skip-checkout option.
