### PR TITLE
Add fetch-depth option to GitHub Actions checkout step

### DIFF
--- a/.github/workflows/qb-build-kafka.yml
+++ b/.github/workflows/qb-build-kafka.yml
@@ -31,6 +31,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Create a New Tag
         uses: netcracker/qubership-workflow-hub/actions/tag-action@main


### PR DESCRIPTION
Include a fetch-depth option in the checkout step of the GitHub Actions
workflow to allow for a full history retrieval.
